### PR TITLE
[fix] add missing (,) in ci.json

### DIFF
--- a/packages/homepage/content/docs/8-ci.md
+++ b/packages/homepage/content/docs/8-ci.md
@@ -66,7 +66,7 @@ These are all the configuration options you can set. They are all optional.
   // where the contents of the built dependency are. These files will be uploaded
   // to our registry
   "publishDirectory": {
-    "react": "build/node_modules/react"
+    "react": "build/node_modules/react",
     "react-dom": "build/node_modules/react-dom"
   },
   // a list of sandboxes that you want generated for a PR, if this list


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add missing (,) in ci.json


## What is the current behavior?
```
"publishDirectory": {
    "react": "build/node_modules/react"
    "react-dom": "build/node_modules/react-dom"
  },
```

## What is the new behavior?
```
"publishDirectory": {
    "react": "build/node_modules/react",
    "react-dom": "build/node_modules/react-dom"
  },
```
- [x] Documentation
- [x] Testing n/a
- [x] Ready to be merged
      YES
